### PR TITLE
Added Microsoft.Workflow.Compiler.exe as a blocked .net binary

### DIFF
--- a/AaronLocker/CustomizationInputs/GetExeFilesToBlacklist.ps1
+++ b/AaronLocker/CustomizationInputs/GetExeFilesToBlacklist.ps1
@@ -26,6 +26,7 @@ $dotnetProgramsToBlacklist =
     "RegSvcs.exe", 
     "MSBuild.exe",
     "Microsoft.Workflow.Compiler.exe"
+    
 $dotnetProgramsToBlacklist | ForEach-Object {
     Get-ChildItem -Path $env:windir\Microsoft.NET -Recurse -Include $_ | ForEach-Object { $_.FullName }
 }

--- a/AaronLocker/CustomizationInputs/GetExeFilesToBlacklist.ps1
+++ b/AaronLocker/CustomizationInputs/GetExeFilesToBlacklist.ps1
@@ -24,7 +24,8 @@ $dotnetProgramsToBlacklist =
     "IEExec.exe", 
     "RegAsm.exe", 
     "RegSvcs.exe", 
-    "MSBuild.exe"
+    "MSBuild.exe",
+    "Microsoft.Workflow.Compiler.exe"
 $dotnetProgramsToBlacklist | ForEach-Object {
     Get-ChildItem -Path $env:windir\Microsoft.NET -Recurse -Include $_ | ForEach-Object { $_.FullName }
 }


### PR DESCRIPTION
Binary can be used to bypass whitelisting.

More info here:
https://posts.specterops.io/arbitrary-unsigned-code-execution-vector-in-microsoft-workflow-compiler-exe-3d9294bc5efb
