### PR TITLE
Big performance and feature update

### DIFF
--- a/AaronLocker/Create-Policies.ps1
+++ b/AaronLocker/Create-Policies.ps1
@@ -164,8 +164,8 @@ if ($Rescan)
 
     # Enumerate user-writable subdirectories in protected directories. Capture grantees so they can be inspected afterwards.
 	Write-Host "Enumerating writable directories in $env:windir" -ForegroundColor Cyan
-    $knownAdmins = @()
-    $knownAdmins += & $ps1_KnownAdmins
+    [System.Collections.ArrayList]$knownAdmins = @()
+    $knownAdmins.AddRange( @(& $ps1_KnownAdmins) )
 	& $ps1_EnumWritableDirs -RootDirectory $env:windir -ShowGrantees -OutputXML -KnownAdmins $knownAdmins | Out-File -Encoding ASCII $windirFullXml
 	Write-Host "Enumerating writable directories in $env:ProgramFiles" -ForegroundColor Cyan
 	& $ps1_EnumWritableDirs -RootDirectory $env:ProgramFiles -ShowGrantees -OutputXML -KnownAdmins $knownAdmins | Out-File -Encoding ASCII $PfFullXml
@@ -343,8 +343,8 @@ $sPF       = "$env:ProgramFiles\".ToLower()
 
 # Build arrays of processed directory names with duplicates removed. (E.g., System32\Com\dmp and
 # SysWOW64\Com\dmp can both be covered with a single entry.)
-$Wr_windir = @()
-$Wr_PF = @()
+[System.Collections.ArrayList]$Wr_windir = @()
+[System.Collections.ArrayList]$Wr_PF = @()
 
 # For the Windows list, replace matching System32, SysWOW64, and Windows paths with corresponding
 # AppLocker variables, then add to collection if not already present.
@@ -356,7 +356,7 @@ $Wr_raw_windir | foreach {
     # Don't add the rule twice if it appears in both System32 and SysWOW64, since both map to %SYSTEM32%.
     if (!$Wr_windir.Contains($dir))
     {
-    	$Wr_windir += $dir
+    	$Wr_windir.Add($dir) | Out-Null
     }
 }
 
@@ -365,7 +365,7 @@ $Wr_raw_windir | foreach {
 $Wr_raw_PF86 | foreach {
 	$dir = $_.ToLower()
 	if ($dir.StartsWith($sPF86))     { $dir = "%PROGRAMFILES%\" + $dir.Substring($sPF86.Length) }
-	$Wr_PF += $dir
+	$Wr_PF.Add($dir) | Out-Null
 }
 
 $Wr_raw_PF | foreach {
@@ -374,7 +374,7 @@ $Wr_raw_PF | foreach {
 	# Possibly already added same directory from PF86; don't add again
 	if (!$Wr_PF.Contains($dir))
 	{
-		$Wr_PF += $dir
+		$Wr_PF.Add($dir) | Out-Null
 	}
 }
 

--- a/AaronLocker/CustomizationInputs/GetSafePathsToAllow.ps1
+++ b/AaronLocker/CustomizationInputs/GetSafePathsToAllow.ps1
@@ -20,7 +20,7 @@ SUBST drive letters, as the user can change their definitions. If X: is mapped t
 in that share whether it is referenced as \\MYSERVER\Apps\MyProgram.exe or as X:\MyProgram.exe. Similarly,
 AppLocker does the right thing with SUBSTed drive letters.
 
-TODO: At some point, reimplement with hashtable output supporting "label" and "RuleCollection" properties so that path rules have more descriptive names, and can be applied to specific rule collections>
+TODO: At some point, reimplement with hashtable output supporting "label" and "RuleCollection" properties so that path rules have more descriptive names, and can be applied to specific rule collections.
 
 #>
 
@@ -53,5 +53,3 @@ if ($null -ne $cs)
 ### Windows Defender put their binaries in ProgramData for a while. Comment this back out when they move it back.
 "%OSDRIVE%\PROGRAMDATA\MICROSOFT\WINDOWS DEFENDER\PLATFORM\*"
 
-# Windows upgrade
-'C:\$WINDOWS.~BT\Sources\*'

--- a/AaronLocker/CustomizationInputs/TrustedSigners-MsvcMfc.ps1
+++ b/AaronLocker/CustomizationInputs/TrustedSigners-MsvcMfc.ps1
@@ -166,6 +166,14 @@ ProductName   = "MICROSOFT® VISUAL STUDIO® 2015";
 BinaryName = "VCRUNTIME140.DLL";
 }
 
+@{
+label = "MFC runtime DLL";
+RuleCollection = "Dll";
+PublisherName = "O=MICROSOFT CORPORATION, L=REDMOND, S=WASHINGTON, C=US";
+ProductName = "MICROSOFT® VISUAL STUDIO® 2015";
+BinaryName = "MFC140U.DLL";
+}
+
 ###########################################################################
 # Visual Studio 2017
 ###########################################################################

--- a/AaronLocker/CustomizationInputs/TrustedSigners.ps1
+++ b/AaronLocker/CustomizationInputs/TrustedSigners.ps1
@@ -72,13 +72,6 @@ ProductName = "MICROSOFT TEAMS";
 }
 
 @{
-# Allow Microsoft-signed files with the Microsoft Teams Update product name.
-label = "Microsoft Teams Update";
-PublisherName = "O=MICROSOFT CORPORATION, L=REDMOND, S=WASHINGTON, C=US";
-ProductName = "MICROSOFT TEAMS UPDATE";
-}
-
-@{
 label = "Microsoft-signed MSI files";
 RuleCollection = "Msi";
 PublisherName = "O=MICROSOFT CORPORATION, L=REDMOND, S=WASHINGTON, C=US";

--- a/AaronLocker/Support/Enum-WritableDirs.ps1
+++ b/AaronLocker/Support/Enum-WritableDirs.ps1
@@ -159,6 +159,7 @@ if ($RootDirectory.EndsWith("\")) { $RootDirectory = $RootDirectory.Substring(0,
 # are not a problem. AppContainers never grant additional access; they only reduce access.
 $FilterOut0 = @"
 S-1-3-0
+S-1-5-6
 S-1-5-18
 S-1-5-19
 S-1-5-20

--- a/AaronLocker/Support/ExportPolicy-ToCsv.ps1
+++ b/AaronLocker/Support/ExportPolicy-ToCsv.ps1
@@ -139,28 +139,28 @@ $x.AppLockerPolicy.RuleCollection | ForEach-Object {
             if ($null -ne $childNode.Exceptions)
             {
                 # Output exceptions with a designated separator character sequence that can be replaced with line feeds in Excel
-                $arrExceptions = @()
+                [System.Collections.ArrayList]$arrExceptions = @()
                 if ($null -ne $childNode.Exceptions.FilePathCondition)
                 {
-                    $arrExceptions += "[----- Path exceptions -----]"
-                    $arrExceptions += ($childNode.Exceptions.FilePathCondition.Path | Sort-Object)
+                    $arrExceptions.Add( "[----- Path exceptions -----]" ) | Out-Null
+                    $arrExceptions.AddRange( @($childNode.Exceptions.FilePathCondition.Path | Sort-Object) )
                 }
                 if ($null -ne $childNode.Exceptions.FilePublisherCondition)
                 {
-                    $arrExceptions += "[----- Publisher exceptions -----]"
-                    $arrExceptions += ($childNode.Exceptions.FilePublisherCondition | 
+                    $arrExceptions.Add( "[----- Publisher exceptions -----]" ) | Out-Null
+                    $arrExceptions.AddRange( @($childNode.Exceptions.FilePublisherCondition | 
                         ForEach-Object {
                             $s = $_.BinaryName + ": " + $_.PublisherName + "; " + $_.ProductName
                             $bvrLow = $_.BinaryVersionRange.LowSection
                             $bvrHigh = $_.BinaryVersionRange.HighSection
                             if ($bvrLow -ne "*" -or $bvrHigh -ne "*") { $s += "; ver " + $bvrLow + " to " + $bvrHigh }
                             $s
-                        } | Sort-Object)
+                        } | Sort-Object) )
                 }
                 if ($null -ne $childNode.Exceptions.FileHashCondition)
                 {
-                    $arrExceptions += "[----- Hash exceptions -----]"
-                    $arrExceptions += ($childNode.Exceptions.FileHashCondition.FileHash | ForEach-Object { $_.SourceFileName + "; length = " + $_.SourceFileLength } | Sort-Object)
+                    $arrExceptions.Add( "[----- Hash exceptions -----]" ) | Out-Null
+                    $arrExceptions.AddRange( @($childNode.Exceptions.FileHashCondition.FileHash | ForEach-Object { $_.SourceFileName + "; length = " + $_.SourceFileLength } | Sort-Object) )
                 }
                 $exceptions = $arrExceptions -join $linebreakSeq
             }

--- a/AaronLocker/Support/SupportFunctions.ps1
+++ b/AaronLocker/Support/SupportFunctions.ps1
@@ -306,7 +306,7 @@ function IsWin32Executable([string]$filename)
 
     # Read first 64 bytes (size of IMAGE_DOS_HEADER)
     # Always make sure returned data is an array, even if the file contains exactly one byte
-    $bytesImageDosHeader = @() + (Get-Content -Encoding Byte -TotalCount $sizeofImageDosHeader $filename -ErrorAction SilentlyContinue)
+    $bytesImageDosHeader = @(Get-Content -Encoding Byte -TotalCount $sizeofImageDosHeader $filename -ErrorAction SilentlyContinue)
     if ($null -eq $bytesImageDosHeader -or $bytesImageDosHeader.Length -lt $sizeofImageDosHeader)
     {
         Write-Verbose "$filename : Non-existent or unreadable file, or less than $sizeofImageDosHeader bytes."


### PR DESCRIPTION
Most scripts perf improved, especially Get-AppLockerEvents.ps1
Get-AppLockerEvents.ps1: now retrieves Packaged App events; now supports named live event logs (for WEC where events written to logs other than ForwardedEvents); (note that some switches changed, and the field-omission switches are dropped).
Generate-EventWorkbook.ps1: can be invoked without parameters - invokes Get-AppLockerEvents.ps1 locally and processes those results.