### PR TITLE
Fix key concatenation in BuildRulesForFilesInWritableDirectories.ps1 

### DIFF
--- a/AaronLocker/Support/BuildRulesForFilesInWritableDirectories.ps1
+++ b/AaronLocker/Support/BuildRulesForFilesInWritableDirectories.ps1
@@ -363,7 +363,7 @@ foreach($alfi in $arrALFI)
                     if ($pubRuleInclBinname -or $MSHighGranularity)
                     {
                         # File-specific rules: add binary name to key
-                        $key = "|" + $pubInfo.BinaryName
+                        $key += "|" + $pubInfo.BinaryName
 
                         # File-specific name/description including full path
                         $rule.Name = $RuleNamePrefix + $pubInfo.BinaryName


### PR DESCRIPTION
This PR fixes an issue in BuildRulesForFilesInWritableDirectories.ps1 where publisher rule keys were incorrectly rebuilt when binary name granularity was enabled.

### Problem

When PubRuleGranularity is set to `pubProductBinary` (default) or
`pubProdBinVer`, the key used for de-duplication is reset instead of appended:

    $key = "|" + $pubInfo.BinaryName

This discards the existing publisher and product components, causing different binaries with the same name (in different directories or with different versions/publishers) to collide. As a result, only one DLL is kept. This matches the behavior reported in Issue #43.

### Fix
Replace key reassignment with concatenation: and allows multiple binaries with the same name to be processed correctly.

### Impact
- Fixes missing rules for duplicated DLL names in different folders
- Affects only key construction logic
- No behavior change for lower-granularity modes

Fixes #43